### PR TITLE
Улучшения в спецификации rpm

### DIFF
--- a/build/rpm/README.md
+++ b/build/rpm/README.md
@@ -22,7 +22,7 @@ chmod +x ./build/run.sh
 Подготовка окружения для установки:
 
 ```shell
-sudo apt-get install gnome-extensions-app libgjs libgtk4-gir libadwaita-gir libsoup-gir
+sudo apt-get install libgjs libgtk4-gir libadwaita-gir libsoup3.0-gir xdg-desktop-portal-xapp
 ```
 
 Установка:

--- a/build/rpm/build.sh
+++ b/build/rpm/build.sh
@@ -55,11 +55,11 @@ BuildRequires: libgtk4-devel
 BuildRequires: libadwaita-devel >= 1.5
 
 Requires: sudo
-Requires: gnome-extensions-app
+Requires: xdg-desktop-portal-xapp
 Requires: libgjs
 Requires: libgtk4-gir
 Requires: libadwaita-gir
-Requires: libsoup-gir
+Requires: libsoup3.0-gir
 
 %description
 %summary.

--- a/build/rpm/build.sh
+++ b/build/rpm/build.sh
@@ -92,7 +92,7 @@ ln -sf %{_bindir}/%{fullname} %{_bindir}/%{name}
 %{_datadir}/locale/ru/LC_MESSAGES/%{fullname}.mo
 
 %postun
-if [ $1 -eq 0 ]; then
+if [ \$1 -eq 0 ]; then
    unlink %{_bindir}/%{name}
 fi
 EOT

--- a/build/rpm/build.sh
+++ b/build/rpm/build.sh
@@ -90,6 +90,11 @@ ln -sf %{_bindir}/%{fullname} %{_bindir}/%{name}
 %{_datadir}/glib-2.0/schemas/%{fullname}.gschema.xml
 %{_datadir}/icons/%{fullname}.svg
 %{_datadir}/locale/ru/LC_MESSAGES/%{fullname}.mo
+
+%postun
+if [ $1 -eq 0 ]; then
+   unlink %{_bindir}/%{name}
+fi
 EOT
 
 # Build


### PR DESCRIPTION
* избавился от огромной зависимости `gnome-extensions-app`, тянущей GNOME. Вместо неё только необходимый интерфейс для определения цветовой схемы в `xdg-desktop-portal-xapp` + пофиксил `libsoup3.0-gir`. 
* если в дальнейшем определение цветовой схемы станет необязательным (#9) , можно будет отказаться и от `xdg-desktop-portal-xapp`.
* добавил код для удаления симлинка на `aurora-toolbox` при удалении rpm-пакета из системы

Полученный rpm проверен в стартеркитах ALT Linux p11 с графическими окружениями GNOME, Cinnamon, MATE, Xfce